### PR TITLE
MDW-3726: Ohif. Unsupported color mode

### DIFF
--- a/platform/viewer/src/connectedComponents/ConnectedStudyBrowser.js
+++ b/platform/viewer/src/connectedComponents/ConnectedStudyBrowser.js
@@ -100,7 +100,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         });
       }
 
-      if (displaySet.images[0]._data.metadata.PhotometricInterpretation === 'YBR_FULL') {
+      if (displaySet && displaySet.images[0] && displaySet.images[0]._data && displaySet.images[0]._data.metadata
+        && displaySet.images[0]._data.metadata.PhotometricInterpretation === 'YBR_FULL') {
         const error = new Error(`Color mode 'YBR Full' not supported`);
         const message = `Color mode 'YBR Full' not supported`;
         LoggerService.error({ error, message });

--- a/platform/viewer/src/connectedComponents/ConnectedStudyBrowser.js
+++ b/platform/viewer/src/connectedComponents/ConnectedStudyBrowser.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import OHIF from '@ohif/core';
 import { connect } from 'react-redux';
 import findDisplaySetByUID from './findDisplaySetByUID';
@@ -90,6 +91,18 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       if (displaySet.isSOPClassUIDSupported === false) {
         const error = new Error('Modality not supported');
         const message = 'Modality not supported';
+        LoggerService.error({ error, message });
+        UINotificationService.show({
+          autoClose: false,
+          title: 'Fail to load series',
+          message,
+          type: 'error',
+        });
+      }
+
+      if (displaySet.images[0]._data.metadata.PhotometricInterpretation === 'YBR_FULL') {
+        const error = new Error(`Color mode 'YBR Full' not supported`);
+        const message = `Color mode 'YBR Full' not supported`;
         LoggerService.error({ error, message });
         UINotificationService.show({
           autoClose: false,

--- a/platform/viewer/src/connectedComponents/ConnectedStudyBrowser.js
+++ b/platform/viewer/src/connectedComponents/ConnectedStudyBrowser.js
@@ -102,8 +102,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 
       if (displaySet && displaySet.images[0] && displaySet.images[0]._data && displaySet.images[0]._data.metadata
         && displaySet.images[0]._data.metadata.PhotometricInterpretation === 'YBR_FULL') {
-        const error = new Error(`Color mode 'YBR Full' not supported`);
-        const message = `Color mode 'YBR Full' not supported`;
+        const error = new Error(`Color mode 'YBR Full' is not supported`);
+        const message = `Color mode 'YBR Full' is not supported`;
         LoggerService.error({ error, message });
         UINotificationService.show({
           autoClose: false,

--- a/platform/viewer/src/connectedComponents/ViewerMain.js
+++ b/platform/viewer/src/connectedComponents/ViewerMain.js
@@ -210,7 +210,8 @@ class ViewerMain extends Component {
       });
     }
 
-    if (displaySet.images[0]._data.metadata.PhotometricInterpretation === 'YBR_FULL') {
+    if (displaySet && displaySet.images[0] && displaySet.images[0]._data && displaySet.images[0]._data.metadata
+      && displaySet.images[0]._data.metadata.PhotometricInterpretation === 'YBR_FULL') {
       const error = new Error(`Color mode 'YBR Full' not supported`);
       const message = `Color mode 'YBR Full' not supported`;
       LoggerService.error({ error, message });

--- a/platform/viewer/src/connectedComponents/ViewerMain.js
+++ b/platform/viewer/src/connectedComponents/ViewerMain.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import './ViewerMain.css';
 import { servicesManager } from './../App.js';
 import { Component } from 'react';
@@ -200,6 +201,18 @@ class ViewerMain extends Component {
     if (displaySet.isSOPClassUIDSupported === false) {
       const error = new Error('Modality not supported');
       const message = 'Modality not supported';
+      LoggerService.error({ error, message });
+      UINotificationService.show({
+        autoClose: false,
+        title: 'Fail to load series',
+        message,
+        type: 'error',
+      });
+    }
+
+    if (displaySet.images[0]._data.metadata.PhotometricInterpretation === 'YBR_FULL') {
+      const error = new Error(`Color mode 'YBR Full' not supported`);
+      const message = `Color mode 'YBR Full' not supported`;
       LoggerService.error({ error, message });
       UINotificationService.show({
         autoClose: false,

--- a/platform/viewer/src/connectedComponents/ViewerMain.js
+++ b/platform/viewer/src/connectedComponents/ViewerMain.js
@@ -212,8 +212,8 @@ class ViewerMain extends Component {
 
     if (displaySet && displaySet.images[0] && displaySet.images[0]._data && displaySet.images[0]._data.metadata
       && displaySet.images[0]._data.metadata.PhotometricInterpretation === 'YBR_FULL') {
-      const error = new Error(`Color mode 'YBR Full' not supported`);
-      const message = `Color mode 'YBR Full' not supported`;
+      const error = new Error(`Color mode 'YBR Full' is not supported`);
+      const message = `Color mode 'YBR Full' is not supported`;
       LoggerService.error({ error, message });
       UINotificationService.show({
         autoClose: false,

--- a/platform/viewer/src/routes/routesUtil.js
+++ b/platform/viewer/src/routes/routesUtil.js
@@ -25,11 +25,13 @@ const StandaloneRouting = asyncComponent(() =>
     )
   )
 );
-// const ViewerLocalFileData = asyncComponent(() =>
-//   retryImport(() => import(
-//     /* webpackChunkName: "ViewerLocalFileData" */ '../connectedComponents/ViewerLocalFileData.js'
-//   ))
-// );
+const ViewerLocalFileData = asyncComponent(() =>
+  retryImport(() =>
+    import(
+      /* webpackChunkName: "ViewerLocalFileData" */ '../connectedComponents/ViewerLocalFileData.js'
+    )
+  )
+);
 
 const reload = () => window.location.reload();
 
@@ -50,10 +52,10 @@ const ROUTES_DEF = {
     //     return appConfig.showStudyList;
     //   },
     // },
-    // local: {
-    //   path: '/local',
-    //   component: ViewerLocalFileData,
-    // },
+    local: {
+      path: '/local',
+      component: ViewerLocalFileData,
+    },
     // IHEInvokeImageDisplay: {
     //   path: '/IHEInvokeImageDisplay',
     //   component: IHEInvokeImageDisplay,


### PR DESCRIPTION
Добавлена проверка для поля PhotometricInterpretation для displaySet по аналогии проверки модальности
В случае если значение равно 'YBR_FULL', выводить читаемую ошибку в консоли и в всплывающем уведомлении пользователю